### PR TITLE
Add devEui as a key in the JSON for MQTT Downlink command

### DIFF
--- a/src/chirpstack/integrations/mqtt.md
+++ b/src/chirpstack/integrations/mqtt.md
@@ -37,6 +37,7 @@ Example payload:
 
 ```json
 {
+    "devEui": "*DEV_EUI*"
     "confirmed": true,                        // whether the payload must be sent as confirmed data down or not
     "fPort": 10,                              // FPort to use (must be > 0)
     "data": "...."                            // base64 encoded data (plaintext, will be encrypted by ChirpStack)


### PR DESCRIPTION
Got an error message when publishing a command downlink saying that there should be a devEui key as part of the payload. This was not properly documented 

ERROR chirpstack::integration::mqtt: Processing command error: Payload dev_eui  does not match topic dev_eui 393736326c308213 topic="application/764576cd-e567-454e-ad7c-91956b40474a/device/393736326c308213/command/down" qos=0