### PR TITLE
Update mosquitto-tls-configuration.md

### DIFF
--- a/src/guides/mosquitto-tls-configuration.md
+++ b/src/guides/mosquitto-tls-configuration.md
@@ -76,7 +76,7 @@ Save the following files to disk:
 Then execute the following command to generate the CA certificate and key:
 
 ```bash
-cfssl gencert -initca ca-csr | cfssljson -bare ca
+cfssl gencert -initca ca-csr.json | cfssljson -bare ca
 ```
 
 ## Generate MQTT server-certificate


### PR DESCRIPTION
requires '.json',  else errors with:

open ca-csr: no such file or directory
Failed to parse input: unexpected end of JSON input