### PR TITLE
Remove {{gateway_os_version}} from paths to get version to install

### DIFF
--- a/src/chirpstack-gateway-os/downloads.md
+++ b/src/chirpstack-gateway-os/downloads.md
@@ -9,10 +9,10 @@ There are two file types:
 
 ## Image links
 
-* [Raspberry Zero W](http://artifacts.chirpstack.io/downloads/chirpstack-gateway-os/raspberrypi/raspberrypi0-wifi/{{gateway_os_version}}/)
-* [Raspberry Pi 1](http://artifacts.chirpstack.io/downloads/chirpstack-gateway-os/raspberrypi/raspberrypi/{{gateway_os_version}}/)
-* [Raspberry Pi 3](http://artifacts.chirpstack.io/downloads/chirpstack-gateway-os/raspberrypi/raspberrypi3/{{gateway_os_version}}/)
-* [Raspberry Pi 4](http://artifacts.chirpstack.io/downloads/chirpstack-gateway-os/raspberrypi/raspberrypi4/{{gateway_os_version}}/)
+* [Raspberry Zero W](http://artifacts.chirpstack.io/downloads/chirpstack-gateway-os/raspberrypi/raspberrypi0-wifi/)
+* [Raspberry Pi 1](http://artifacts.chirpstack.io/downloads/chirpstack-gateway-os/raspberrypi/raspberrypi/)
+* [Raspberry Pi 3](http://artifacts.chirpstack.io/downloads/chirpstack-gateway-os/raspberrypi/raspberrypi3/)
+* [Raspberry Pi 4](http://artifacts.chirpstack.io/downloads/chirpstack-gateway-os/raspberrypi/raspberrypi4/)
 
 ## SD card flashing
 


### PR DESCRIPTION
 Links to install the OS version is outdated, and I think it's a risk that it will always be outdated. So I propose removing the version number from the link and then giving the user possibility to choose which version he wants to install. But he always will see the most recent version to install.